### PR TITLE
Changed input params to match documentation

### DIFF
--- a/arm-ttk-extension-xplatform/powershell/ps-runner.ps1
+++ b/arm-ttk-extension-xplatform/powershell/ps-runner.ps1
@@ -3,9 +3,9 @@
 Param(
     $templatelocation,
     $resultlocation,
-    $TestString,
-    $SkipString,
-    $mainTemplateString,
+    $IncludeTests,
+    $SkipTests,
+    $MainTemplates,
     [switch]$allTemplatesAreMain,
     [switch]$cliOutputResults,
     [switch]$ignoreExitCode,
@@ -16,22 +16,22 @@ Import-Module "$PSScriptRoot\..\arm-ttk\arm-ttk.psd1"
 Import-Module "$PSScriptRoot\Export-NUnitXml.psm1"
 Import-Module "$PSScriptRoot\invoke-ttk.psm1"
 
-if($TestString){
-    $Test=$TestString.split(',').trim()
+if($IncludeTests){
+    $Test=$IncludeTests.split(',').trim()
 }
 else{
     $Test =@()
 }
 
-if($SkipString){
-    $Skip=$SkipString.split(',').trim()
+if($SkipTests){
+    $Skip=$SkipTests.split(',').trim()
 }
 else{
     $Skip =@()
 }
 
-if($mainTemplateString){
-    $mainTemplates=$mainTemplateString.split(',').trim()
+if($MainTemplates){
+    $mainTemplates=$MainTemplates.split(',').trim()
 }
 else{
     $mainTemplates =@()

--- a/arm-ttk-extension-xplatform/powershell/ps-runner.ps1
+++ b/arm-ttk-extension-xplatform/powershell/ps-runner.ps1
@@ -1,11 +1,11 @@
 [CmdletBinding()] 
 [CmdletBinding()]
 Param(
-    $templatelocation,
-    $resultlocation,
-    $IncludeTests,
-    $SkipTests,
-    $MainTemplates,
+    $templateLocation,
+    $resultLocation,
+    $includeTests,
+    $skipTests,
+    $mainTemplates,
     [switch]$allTemplatesAreMain,
     [switch]$cliOutputResults,
     [switch]$ignoreExitCode,
@@ -17,25 +17,25 @@ Import-Module "$PSScriptRoot\Export-NUnitXml.psm1"
 Import-Module "$PSScriptRoot\invoke-ttk.psm1"
 
 if($IncludeTests){
-    $Test=$IncludeTests.split(',').trim()
+    $Test=$includeTests.split(',').trim()
 }
 else{
     $Test =@()
 }
 
 if($SkipTests){
-    $Skip=$SkipTests.split(',').trim()
+    $Skip=$skipTests.split(',').trim()
 }
 else{
     $Skip =@()
 }
 
 if($MainTemplates){
-    $mainTemplates=$MainTemplates.split(',').trim()
+    $Main=$mainTemplates.split(',').trim()
 }
 else{
-    $mainTemplates =@()
+    $Main =@()
 }
 
 
-Invoke-TTK -templatelocation $templatelocation  -resultlocation $resultlocation -Test $Test -Skip $Skip -mainTemplates $mainTemplates -allTemplatesAreMain $allTemplatesAreMain -cliOutputResults $cliOutputResults -ignoreExitCode $ignoreExitCode -recurse $recurse
+Invoke-TTK -templateLocation $templateLocation  -resultLocation $resultLocation -Test $Test -Skip $Skip -mainTemplates $Main -allTemplatesAreMain $allTemplatesAreMain -cliOutputResults $cliOutputResults -ignoreExitCode $ignoreExitCode -recurse $recurse

--- a/arm-ttk-extension-xplatform/task.json
+++ b/arm-ttk-extension-xplatform/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 8
+        "Patch": 9
     },
     "instanceNameFormat": "Run Azure RM TTK Tests (Cross Platform)",
     "groups": [

--- a/arm-ttk-extension-xplatform/task.json
+++ b/arm-ttk-extension-xplatform/task.json
@@ -35,7 +35,7 @@
         "type": "boolean",
         "label": "Recurse Template Location",
         "required": false,
-        "helpMarkDown": "Recurse through all folders undeneath template location",
+        "helpMarkDown": "Recurse through all folders underneath template location",
         "defaultValue": true
       },
       {
@@ -51,21 +51,21 @@
         "type": "string",
         "label": "Tests to Include",
         "required": false,
-        "helpMarkDown": "Comma seperated list of specific test to run, leave blank to run all tests."
+        "helpMarkDown": "Comma separated list of specific test to run, leave blank to run all tests."
       },
       {
         "name": "skipTests",
         "type": "string",
         "label": "Tests to Skip",
         "required": false,
-        "helpMarkDown": "Comma seperated list of specific test to skip, leave blank to run all tests."
+        "helpMarkDown": "Comma separated list of specific test to skip, leave blank to run all tests."
       },
       {
         "name": "mainTemplates",
         "type": "string",
         "label": "Main Templates List",
         "required": false,
-        "helpMarkDown": "Comma seperated list of templates to be marked as a 'main' template for the purposes of tests such as location hardcoding, leave blank to not mark any templates or rely on naming convention"
+        "helpMarkDown": "Comma separated list of templates to be marked as a 'main' template for the purposes of tests such as location hardcoding, leave blank to not mark any templates or rely on naming convention"
 
       },
       {

--- a/arm-ttk-extension-xplatform/ttk.js
+++ b/arm-ttk-extension-xplatform/ttk.js
@@ -17,9 +17,9 @@ function run() {
         try {
             let templatelocation = tl.getInput("templatelocation", true);
             let resultlocation = tl.getInput("resultlocation", true);
-            let testString = tl.getInput("testString");
-            let skipString = tl.getInput("skipString");
-            let mainTemplateString = tl.getInput("mainTemplateString");
+            let includeTests = tl.getInput("includeTests");
+            let skipTests = tl.getInput("skipTests");
+            let mainTemplates = tl.getInput("mainTemplates");
             let allTemplatesAreMain = tl.getBoolInput("allTemplatesAreMain");
             let cliOutputResults = tl.getBoolInput("cliOutputResults");
             let ignoreExitCode = tl.getBoolInput("ignoreExitCode");
@@ -32,10 +32,10 @@ function run() {
                 if (!tl.getBoolInput("usePSCore")) {
                     executable = "powershell.exe";
                 }
-                agentSpecific_1.logInfo(`Using executable '${executable}'`);
+                (0, agentSpecific_1.logInfo)(`Using executable '${executable}'`);
             }
             else {
-                agentSpecific_1.logInfo(`Using executable '${executable}' as only only option on '${tl.getVariable("AGENT.OS")}'`);
+                (0, agentSpecific_1.logInfo)(`Using executable '${executable}' as only only option on '${tl.getVariable("AGENT.OS")}'`);
             }
             // we need to not pass the null param
             var args = [__dirname + "\\powershell\\ps-runner.ps1"];
@@ -47,17 +47,17 @@ function run() {
                 args.push("-resultlocation");
                 args.push(resultlocation);
             }
-            if (testString) {
-                args.push("-testString");
-                args.push(testString);
+            if (includeTests) {
+                args.push("-includeTests");
+                args.push(includeTests);
             }
-            if (skipString) {
-                args.push("-skipString");
-                args.push(skipString);
+            if (skipTests) {
+                args.push("-skipTests");
+                args.push(skipTests);
             }
-            if (mainTemplateString) {
-                args.push("-mainTemplateString");
-                args.push(mainTemplateString);
+            if (mainTemplates) {
+                args.push("-mainTemplates");
+                args.push(mainTemplates);
             }
             if (allTemplatesAreMain) {
                 args.push("-allTemplatesAreMain");
@@ -71,21 +71,21 @@ function run() {
             if (recurse) {
                 args.push("-recurse");
             }
-            agentSpecific_1.logInfo(`${executable} ${args.join(" ")}`);
+            (0, agentSpecific_1.logInfo)(`${executable} ${args.join(" ")}`);
             var spawn = require("child_process").spawn, child;
             child = spawn(executable, args);
             child.stdout.on("data", function (data) {
-                agentSpecific_1.logInfo(data.toString());
+                (0, agentSpecific_1.logInfo)(data.toString());
             });
             child.stderr.on("data", function (data) {
-                agentSpecific_1.logError(data.toString());
+                (0, agentSpecific_1.logError)(data.toString());
             });
             child.on("exit", function () {
-                agentSpecific_1.logInfo("Script finished");
+                (0, agentSpecific_1.logInfo)("Script finished");
             });
         }
         catch (err) {
-            agentSpecific_1.logError(err);
+            (0, agentSpecific_1.logError)(err);
         }
     });
 }

--- a/arm-ttk-extension-xplatform/ttk.ts
+++ b/arm-ttk-extension-xplatform/ttk.ts
@@ -13,9 +13,9 @@ export async function run() {
 
         let templatelocation = tl.getInput("templatelocation", true);
         let resultlocation = tl.getInput("resultlocation", true);
-        let testString = tl.getInput("testString");
-        let skipString = tl.getInput("skipString");
-        let mainTemplateString = tl.getInput("mainTemplateString");
+        let includeTests = tl.getInput("includeTests");
+        let skipTests = tl.getInput("skipTests");
+        let mainTemplates = tl.getInput("mainTemplates");
         let allTemplatesAreMain = tl.getBoolInput("allTemplatesAreMain");
         let cliOutputResults = tl.getBoolInput("cliOutputResults");
         let ignoreExitCode = tl.getBoolInput("ignoreExitCode");
@@ -49,19 +49,19 @@ export async function run() {
             args.push(resultlocation);
         }
 
-        if (testString) {
-            args.push("-testString");
-            args.push(testString);
+        if (includeTests) {
+            args.push("-includeTests");
+            args.push(includeTests);
         }
 
-        if (skipString) {
-            args.push("-skipString");
-            args.push(skipString);
+        if (skipTests) {
+            args.push("-skipTests");
+            args.push(skipTests);
         }
 
-        if (mainTemplateString) {
-            args.push("-mainTemplateString");
-            args.push(mainTemplateString);
+        if (mainTemplates) {
+            args.push("-mainTemplates");
+            args.push(mainTemplates);
         }
 
         if (allTemplatesAreMain) {

--- a/arm-ttk-extension-xplatform/ttk.ts
+++ b/arm-ttk-extension-xplatform/ttk.ts
@@ -11,8 +11,8 @@ export async function run() {
     try {
 
 
-        let templatelocation = tl.getInput("templatelocation", true);
-        let resultlocation = tl.getInput("resultlocation", true);
+        let templateLocation = tl.getInput("templateLocation", true);
+        let resultLocation = tl.getInput("resultLocation", true);
         let includeTests = tl.getInput("includeTests");
         let skipTests = tl.getInput("skipTests");
         let mainTemplates = tl.getInput("mainTemplates");
@@ -24,7 +24,7 @@ export async function run() {
         // we need to get the verbose flag passed in as script flag
         var verbose = (tl.getVariable("System.Debug") === "true");
 
-        // find the executeable
+        // find the executable
         let executable = "pwsh";
         if (tl.getVariable("AGENT.OS") === "Windows_NT") {
             if (!tl.getBoolInput("usePSCore")) {
@@ -39,14 +39,14 @@ export async function run() {
         var args = [__dirname + "\\powershell\\ps-runner.ps1"];
 
 
-        if (templatelocation) {
-            args.push("-templatelocation");
-            args.push(templatelocation);
+        if (templateLocation) {
+            args.push("-templateLocation");
+            args.push(templateLocation);
         }
 
-        if (resultlocation) {
-            args.push("-resultlocation");
-            args.push(resultlocation);
+        if (resultLocation) {
+            args.push("-resultLocation");
+            args.push(resultLocation);
         }
 
         if (includeTests) {


### PR DESCRIPTION
The following parameters did not match the documentation or the Windows version of the Task:

|Parameter should be | .. but was |
|---------------------|----------|
| skipTests | skipString|
| includeTests | testString|
| mainTemplates | mainTemplateString|

Also fixed some casing inconsistencies and included a few spelling typos (now come to think of it it, that may be a difference between the US and UK spelling)
- [X] Ran Pester tests
- [X] Verified by running Task locally