### PR TITLE
Fix bug when passing in a single bicep file

### DIFF
--- a/arm-ttk-extension-xplatform/powershell/invoke-ttk.psm1
+++ b/arm-ttk-extension-xplatform/powershell/invoke-ttk.psm1
@@ -114,6 +114,10 @@ Function Invoke-TTK {
                 & $bicepCommand build $bicepFile
             }
         }
+
+        if (!($item -is [System.IO.DirectoryInfo])) {
+            $templatelocation = $templatelocation.replace(".bicep",".json")
+        }
     }
 
     if($recurse){


### PR DESCRIPTION
Fix an issue where if you pass in a single bicep file it will then not find the compiled json file and error with a message about not json files found.