### PR TITLE
Add quotes around the includetests and skiptests parameters

### DIFF
--- a/arm-ttk-extension-xplatform/ttk.ts
+++ b/arm-ttk-extension-xplatform/ttk.ts
@@ -58,7 +58,7 @@ export async function run() {
 
         if (skipTests) {
             args.push("-skipTests");
-            args.push(skipTests);
+            args.push(`'${skipTests}'`);
         }
 
         if (mainTemplates) {

--- a/arm-ttk-extension-xplatform/ttk.ts
+++ b/arm-ttk-extension-xplatform/ttk.ts
@@ -53,7 +53,7 @@ export async function run() {
 
         if (includeTests) {
             args.push("-includeTests");
-            args.push(includeTests);
+            args.push(`'${includeTests}'`);
         }
 
         if (skipTests) {


### PR DESCRIPTION
Fixes #27 

If a comma separated list is passed to the `skiptest` parameter an error is thrown

> ##[error]process argument transformation on parameter 'clientSecret'. Cannot convert value to type System.String.

The fix appears to be to enclose the list of `skiptest` within quotes when added to the inner `ps_runner.ps1` script
